### PR TITLE
Clean npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
     "rollup-plugin-node-globals": "^1.2.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "serve": "^6.3.1"
-  },
-  "dependencies": {
-    "npm-check-updates": "^2.14.1"
   }
 }


### PR DESCRIPTION
First, thanks for this amazing library!
We are using `differenceequationsignal1d` in our LORIS EEG visualization component and have recently dealing with more than 40 security alerts for vulnerabilities introduced by outdated dependencies from `differenceequationsignal1d`.

`differenceequationsignal1d` declares an old version of `npm-check-updates` as a dependency which requires more than 30 other dependencies that causes those issues. I propose to remove the dependency since `npm-check-updates` is a tool that can be installed and run globally.